### PR TITLE
fix: readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'paypal_sandbox' => [
-  'client_id' => env('PAYPALSANDBOX_CLIENT_ID'),
-  'client_secret' => env('PAYPALSANDBOX_CLIENT_SECRET'),
-  'redirect' => env('PAYPALSANDBOX_REDIRECT_URI')
+'paypal_sandbox' => [    
+  'client_id' => env('PAYPALSANDBOX_CLIENT_ID'),  
+  'client_secret' => env('PAYPALSANDBOX_CLIENT_SECRET'),  
+  'redirect' => env('PAYPALSANDBOX_REDIRECT_URI') 
 ],
 ```
 
@@ -43,6 +43,6 @@ return Socialite::driver('paypal_sandbox')->redirect();
 
 ### Returned User fields
 
--   `id`
--   `name`
--   `email`
+- ``id``
+- ``name``
+- ``email``


### PR DESCRIPTION
There was a typo in the readme for the composer require that needed to be changed to paypal-sandbox
